### PR TITLE
feat(users): Implement get and update user profile endpoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,13 @@
 {
   "editor.formatOnSave": true,
+  "editor.formatOnType": true,
   "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.detectIndentation": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.cursorStyle": "line",
+  "editor.cursorBlinking": "smooth",
+  "editor.cursorSmoothCaretAnimation": true,
   "files.exclude": {
     "**/.git": true,
     "**/node_modules": true,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,9 +1,7 @@
-import { Body, Controller, Post, UnauthorizedException, UseGuards, Request,Get } from '@nestjs/common';
+import { Body, Controller, Post, UnauthorizedException} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SignUpDto } from './dto/signup.dto';
 import { SignInDto } from './dto/signin.dto';
-import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth } from '@nestjs/swagger';
 
 @Controller('api/auth')
 export class AuthController {
@@ -25,10 +23,4 @@ export class AuthController {
     return this.authService.login(user);
   }
 
-  @ApiBearerAuth()
-  @UseGuards(AuthGuard('jwt'))
-  @Get('profile')
-  getProfile(@Request() req) {
-    return req.user;
-  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import * as bcrypt from 'bcrypt';
 import { SignUpDto } from './dto/signup.dto';
 import { User } from '@prisma/client';
 import { SignInDto } from './dto/signin.dto';
+import { BCRYPT_SALT_ROUNDS } from 'src/constants/bcrypt.constant';
 
 @Injectable()
 export class AuthService {
@@ -29,8 +30,7 @@ export class AuthService {
       throw new ConflictException('Username đã tồn tại');
     }
 
-    const saltRounds = 10;
-    const hashedPassword = await bcrypt.hash(password, saltRounds);
+    const hashedPassword = await bcrypt.hash(password, BCRYPT_SALT_ROUNDS,);
 
     const user = await this.usersService.create({
       email,

--- a/src/auth/decorator/get-user.decorator.ts
+++ b/src/auth/decorator/get-user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const GetUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const user = request.user;
+    return user;
+  },
+);

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -23,7 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('User not found or token is invalid');
     }
     return {
-      userId: payload.sub,
+      id: payload.sub,
       email: payload.email,
       username: user.username,
       avatar: user.avatar,

--- a/src/constants/bcrypt.constant.ts
+++ b/src/constants/bcrypt.constant.ts
@@ -1,0 +1,1 @@
+export const BCRYPT_SALT_ROUNDS = 10;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,16 @@
-
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(new ValidationPipe({
+    whitelist: true,               
+    forbidNonWhitelisted: true,    
+    transform: true,              
+  }));
 
   const config = new DocumentBuilder()
     .setTitle('Medium')

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -23,10 +23,8 @@ export class UpdateUserDto {
   password?: string;
 
   @ValidateIf((o) => o.password !== undefined)
-  @IsNotEmpty({ message: 'Vui lòng nhập lại mật khẩu để xác nhận' })
-  @Validate(IsPasswordMatchingConstraint, {
-    message: 'Mật khẩu không khớp',
-  })
+  @IsNotEmpty({ message: 'Mật khẩu không được bỏ trống'})
+  @Validate(IsPasswordMatchingConstraint)
   passwordConfirmation?: string;
 
   @IsOptional()

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,0 +1,39 @@
+import { IsNotEmpty, IsOptional, IsString, IsUrl, Validate, ValidateIf, ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+
+@ValidatorConstraint({ name: 'isPasswordMatching', async: false })
+export class IsPasswordMatchingConstraint implements ValidatorConstraintInterface {
+  validate(passwordConfirmation: string, args: ValidationArguments) {
+    const obj = args.object as UpdateUserDto;
+    if (!obj.password || !passwordConfirmation) return true;
+    return obj.password === passwordConfirmation;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return 'Mật khẩu nhập lại không khớp với mật khẩu bạn đặt';
+  }
+}
+
+export class UpdateUserDto {
+  @IsOptional()
+  @IsString()
+  username?: string;
+
+  @IsOptional()
+  @IsString()
+  password?: string;
+
+  @ValidateIf((o) => o.password !== undefined)
+  @IsNotEmpty({ message: 'Vui lòng nhập lại mật khẩu để xác nhận' })
+  @Validate(IsPasswordMatchingConstraint, {
+    message: 'Mật khẩu không khớp',
+  })
+  passwordConfirmation?: string;
+
+  @IsOptional()
+  @IsString()
+  bio?: string;
+
+  @IsOptional()
+  @IsUrl()
+  avatar?: string;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, UseGuards, Request, Body, Patch } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { UsersService } from './users.service';
+import { ApiBearerAuth } from '@nestjs/swagger';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { User } from '@prisma/client';
+import { GetUser } from 'src/auth/decorator/get-user.decorator';
+
+@ApiBearerAuth()
+@UseGuards(AuthGuard('jwt'))
+@Controller('api')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('profile')
+  async getProfile(@GetUser() user: User) { 
+    const fullUserInfo = await this.usersService.findById(user.id);
+    return fullUserInfo;
+  }
+  
+  @Patch('user')
+  updateProfile(@GetUser() user: User, @Body() updateUserDto: UpdateUserDto) {
+    return this.usersService.update(user.id, updateUserDto);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
 
 @Module({
   providers: [UsersService],
   exports: [UsersService],
+  controllers: [UsersController],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { User, Prisma } from '@prisma/client';
+import { UpdateUserDto } from './dto/update-user.dto';
+import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class UsersService {
@@ -22,9 +24,53 @@ export class UsersService {
     });
   }
 
+  async findById(id: number) {
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+    });
+    if (user) {
+      const { password, ...result } = user;
+      return result;
+    }
+    return null;
+  }
+
   async create(data: Prisma.UserCreateInput): Promise<User> {
     return this.prisma.user.create({
       data,
     });
   }
+
+  async update(id: number, updateUserDto: UpdateUserDto) {
+    const dataToUpdate: Prisma.UserUpdateInput = {};
+
+    if (updateUserDto.username) {
+      dataToUpdate.username = updateUserDto.username;
+    }
+    
+    if (updateUserDto.bio) {
+      dataToUpdate.bio = updateUserDto.bio;
+    }
+
+    if (updateUserDto.avatar) {
+      dataToUpdate.avatar = updateUserDto.avatar;
+    }
+
+    if (updateUserDto.password) {
+      const saltRounds = 10;
+      dataToUpdate.password = await bcrypt.hash(
+        updateUserDto.password,
+        saltRounds,
+      );
+    }
+    
+    const updatedUser = await this.prisma.user.update({
+      where: { id },
+      data: dataToUpdate,
+    });
+    
+    const { password, ...result } = updatedUser;
+    return result;
+  }
+
 }


### PR DESCRIPTION
Pull request này mở rộng chức năng quản lý người dùng bằng cách xây dựng các API endpoint cần thiết cho trang "Cài đặt" (Settings Page). Nó cho phép người dùng đã được xác thực có thể đọc (Read) và cập nhật (Update) thông tin cá nhân của chính họ. Hoàn thiện CRU (Create, Read, Update) cho người dùng.
Thay đổi chính

API:
- GET /api/profile: Xây dựng một endpoint mới, được bảo vệ để người dùng đã đăng nhập có thể lấy thông tin profile mới nhất.
- PATCH /api/user: Xây dựng một endpoint mới, được bảo vệ để người dùng có thể cập nhật thông tin cá nhân.

Validation & DTO:
- Tạo UpdateUserDto để validate dữ liệu đầu vào cho việc cập nhật profile.
- Implement logic validation tùy chỉnh để đảm bảo password và passwordConfirmation phải khớp nhau nếu người dùng muốn đổi mật khẩu.
- 
Refactoring (Tái cấu trúc):
Di chuyển logic: Di chuyển chức năng lấy profile từ /api/auth/profile (route dùng để test ở PR trước) sang /api/profile.. Route /api/auth/profile đã được loại bỏ.
Custom Decorator: Giới thiệu decorator @GetUser() để lấy thông tin người dùng từ request một cách gọn gàng và có thể tái sử dụng, thay thế cho việc truy cập req.user lặp đi lặp lại.