### PR TITLE
feat(articles): Implement get, update, put, delete articles endpoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.cursorStyle": "line",
   "editor.cursorBlinking": "smooth",
-  "editor.cursorSmoothCaretAnimation": true,
+  "editor.cursorSmoothCaretAnimation": "on",
   "files.exclude": {
     "**/.git": true,
     "**/node_modules": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "slugify": "^1.6.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -10656,6 +10657,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/sort-keys": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "slugify": "^1.6.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/prisma/migrations/20250717161620_add_article_model/migration.sql
+++ b/prisma/migrations/20250717161620_add_article_model/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE `Article` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `slug` VARCHAR(191) NOT NULL,
+    `title` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NULL,
+    `content` VARCHAR(191) NOT NULL,
+    `published` BOOLEAN NOT NULL DEFAULT false,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `authorId` INTEGER NOT NULL,
+
+    UNIQUE INDEX `Article_slug_key`(`slug`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Article` ADD CONSTRAINT `Article_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,4 +22,20 @@ model User {
   bio       String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  articles  Article[]
+}
+
+model Article {
+  id          Int      @id @default(autoincrement())
+  slug        String   @unique
+  title       String
+  description String?
+  content     String
+  published   Boolean  @default(false)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,9 +4,10 @@ import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
+import { ArticlesModule } from './articles/articles.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, UsersModule],
+  imports: [PrismaModule, AuthModule, UsersModule, ArticlesModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -22,26 +22,26 @@ import { PaginationDto } from 'src/common/pagination.dto';
 export class ArticlesController {
   constructor(private readonly articlesService: ArticlesService) {}
 
-  @Get('all')
+  @Get()
   getListArticles(@Query() paginationDto: PaginationDto) {
     return this.articlesService.findAll(paginationDto);
   }
 
   @Get(':slug')
-  findOneBySlug(@Param('slug') slug: string) {
+  findBySlug(@Param('slug') slug: string) {
     return this.articlesService.findBySlug(slug);
   }
 
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
-  @Post('')
+  @Post()
   create(@Body() createArticleDto: CreateArticleDto, @GetUser() user: User) {
     return this.articlesService.create(createArticleDto, user.id);
   }
 
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
-  @Get('')
+  @Get('me')
   getMyArticles(@GetUser() user: User, @Query() paginationDto: PaginationDto) {
     return this.articlesService.findUserArticles(user.id, paginationDto);
   }

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Delete,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+  Body,
+} from '@nestjs/common';
+import { ArticlesService } from './articles.service';
+import { ApiBearerAuth } from '@nestjs/swagger';
+import { CreateArticleDto } from './dto/create-article.dto';
+import { GetUser } from 'src/auth/decorator/get-user.decorator';
+import { AuthGuard } from '@nestjs/passport';
+import { User } from 'generated/prisma';
+
+@Controller('api')
+export class ArticlesController {
+  constructor(private readonly articlesService: ArticlesService) {}
+
+  @Get('articles/all')
+  GetListArticles() {
+    return this.articlesService.findAll();
+  }
+
+  @Get('articles/:slug')
+  findOneBySlug(@Param('slug') slug: string) {
+    return this.articlesService.findBySlug(slug);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Post('articles')
+  create(@Body() createArticleDto: CreateArticleDto, @GetUser() user: User) {
+    return this.articlesService.create(createArticleDto, user.id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Get('articles')
+  GetMyArticles(@GetUser() user: User) {
+    return this.articlesService.findDrafts(user.id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Put('articles/:slug')
+  update(
+    @Param('slug') slug: string,
+    @Body() createArticleDto: CreateArticleDto,
+    @GetUser() user: User,
+  ) {
+    return this.articlesService.update(slug, createArticleDto, user.id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Delete('articles/:slug')
+  delete(@Param('slug') slug: string, @GetUser() user: User) {
+    return this.articlesService.delete(slug, user.id);
+  }
+}

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -8,6 +8,7 @@ import {
   Post,
   UseGuards,
   Body,
+  Query,
 } from '@nestjs/common';
 import { ArticlesService } from './articles.service';
 import { ApiBearerAuth } from '@nestjs/swagger';
@@ -15,38 +16,39 @@ import { CreateArticleDto } from './dto/create-article.dto';
 import { GetUser } from 'src/auth/decorator/get-user.decorator';
 import { AuthGuard } from '@nestjs/passport';
 import { User } from 'generated/prisma';
+import { PaginationDto } from 'src/common/pagination.dto';
 
-@Controller('api')
+@Controller('api/articles')
 export class ArticlesController {
   constructor(private readonly articlesService: ArticlesService) {}
 
-  @Get('articles/all')
-  GetListArticles() {
-    return this.articlesService.findAll();
+  @Get('all')
+  getListArticles(@Query() paginationDto: PaginationDto) {
+    return this.articlesService.findAll(paginationDto);
   }
 
-  @Get('articles/:slug')
+  @Get(':slug')
   findOneBySlug(@Param('slug') slug: string) {
     return this.articlesService.findBySlug(slug);
   }
 
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
-  @Post('articles')
+  @Post('')
   create(@Body() createArticleDto: CreateArticleDto, @GetUser() user: User) {
     return this.articlesService.create(createArticleDto, user.id);
   }
 
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
-  @Get('articles')
-  GetMyArticles(@GetUser() user: User) {
-    return this.articlesService.findDrafts(user.id);
+  @Get('')
+  getMyArticles(@GetUser() user: User, @Query() paginationDto: PaginationDto) {
+    return this.articlesService.findUserArticles(user.id, paginationDto);
   }
 
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
-  @Put('articles/:slug')
+  @Put(':slug')
   update(
     @Param('slug') slug: string,
     @Body() createArticleDto: CreateArticleDto,
@@ -57,7 +59,7 @@ export class ArticlesController {
 
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))
-  @Delete('articles/:slug')
+  @Delete(':slug')
   delete(@Param('slug') slug: string, @GetUser() user: User) {
     return this.articlesService.delete(slug, user.id);
   }

--- a/src/articles/articles.module.ts
+++ b/src/articles/articles.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ArticlesController } from './articles.controller';
+import { ArticlesService } from './articles.service';
+
+@Module({
+  controllers: [ArticlesController],
+  providers: [ArticlesService]
+})
+export class ArticlesModule {}

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -8,6 +8,8 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateArticleDto } from './dto/create-article.dto';
 import { UpdateArticleDto } from './dto/update-article.dto';
 import slugify from 'slugify';
+import { skip } from 'rxjs';
+import { PaginationDto } from 'src/common/pagination.dto';
 
 @Injectable()
 export class ArticlesService {
@@ -37,17 +39,61 @@ export class ArticlesService {
     });
   }
 
-  findAll() {
-    return this.prisma.article.findMany({
-      include: { author: { select: { username: true } } },
-    });
+  async findAll(paginationDto: PaginationDto) {
+    const { page = 1, limit = 10 } = paginationDto;
+    const skip = (page - 1) * limit;
+
+    const [total, articles] = await this.prisma.$transaction([
+      this.prisma.article.count(),
+      this.prisma.article.findMany({
+        include: { author: { select: { username: true } } },
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+    ]);
+
+    const totalPages = Math.ceil(total / limit);
+
+    return {
+      data: articles,
+      meta: {
+        totalItems: total,
+        itemsPerPage: limit,
+        totalPages: totalPages,
+        currentPage: page,
+      },
+    };
   }
 
-  findDrafts(authorId: number) {
-    return this.prisma.article.findMany({
-      where: { authorId: authorId },
-      include: { author: { select: { username: true } } },
-    });
+  async findUserArticles(authorId: number, paginationDto: PaginationDto) {
+    const { page = 1, limit = 10 } = paginationDto;
+    const skip = (page - 1) * limit;
+
+    const whereClause = { authorId: authorId };
+
+    const [total, articles] = await this.prisma.$transaction([
+      this.prisma.article.count({ where: whereClause }),
+      this.prisma.article.findMany({
+        where: whereClause,
+        include: { author: { select: { username: true } } },
+        skip: skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+    ]);
+
+    const totalPages = Math.ceil(total / limit);
+
+    return {
+      data: articles,
+      meta: {
+        totalItems: total,
+        itemsPerPage: limit,
+        totalPages: totalPages,
+        currentPage: page,
+      },
+    };
   }
 
   async findBySlug(slug: string) {
@@ -61,11 +107,7 @@ export class ArticlesService {
     return article;
   }
 
-  async update(
-    slug: string,
-    updateArticleDto: UpdateArticleDto,
-    userId: number,
-  ) {
+  private async validateArticleAccess(slug: string, userId: number) {
     const article = await this.prisma.article.findUnique({ where: { slug } });
 
     if (!article) {
@@ -73,8 +115,20 @@ export class ArticlesService {
     }
 
     if (article.authorId !== userId) {
-      throw new ForbiddenException('Bạn không có quyền chỉnh sửa bài viết!');
+      throw new ForbiddenException(
+        'Bạn không có quyền thực hiện hành động này!',
+      );
     }
+
+    return article;
+  }
+
+  async update(
+    slug: string,
+    updateArticleDto: UpdateArticleDto,
+    userId: number,
+  ) {
+    await this.validateArticleAccess(slug, userId);
 
     return this.prisma.article.update({
       where: { slug },
@@ -83,15 +137,7 @@ export class ArticlesService {
   }
 
   async delete(slug: string, userId: number) {
-    const article = await this.prisma.article.findUnique({ where: { slug } });
-
-    if (!article) {
-      throw new NotFoundException(`Không tìm thấy bài viết.`);
-    }
-
-    if (article.authorId !== userId) {
-      throw new ForbiddenException('Bạn không có quyền xoá bài viết!');
-    }
+    await this.validateArticleAccess(slug, userId);
 
     return this.prisma.article.delete({ where: { slug } });
   }

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -1,0 +1,98 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateArticleDto } from './dto/create-article.dto';
+import { UpdateArticleDto } from './dto/update-article.dto';
+import slugify from 'slugify';
+
+@Injectable()
+export class ArticlesService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(createArticleDto: CreateArticleDto, authorId: number) {
+    const slug = slugify(createArticleDto.title, {
+      lower: true,
+      strict: true,
+      trim: true,
+    });
+
+    const existingArticle = await this.prisma.article.findUnique({
+      where: { slug },
+    });
+
+    if (existingArticle) {
+      throw new ConflictException('Bài viết với tiêu đề này đã tồn tại');
+    }
+
+    return this.prisma.article.create({
+      data: {
+        ...createArticleDto,
+        slug: slug,
+        authorId: authorId,
+      },
+    });
+  }
+
+  findAll() {
+    return this.prisma.article.findMany({
+      include: { author: { select: { username: true } } },
+    });
+  }
+
+  findDrafts(authorId: number) {
+    return this.prisma.article.findMany({
+      where: { authorId: authorId },
+      include: { author: { select: { username: true } } },
+    });
+  }
+
+  async findBySlug(slug: string) {
+    const article = await this.prisma.article.findUnique({
+      where: { slug },
+      include: { author: { select: { username: true } } },
+    });
+    if (!article) {
+      throw new NotFoundException(`Không tìm thấy bài viết.`);
+    }
+    return article;
+  }
+
+  async update(
+    slug: string,
+    updateArticleDto: UpdateArticleDto,
+    userId: number,
+  ) {
+    const article = await this.prisma.article.findUnique({ where: { slug } });
+
+    if (!article) {
+      throw new NotFoundException(`Không tìm thấy bài viết.`);
+    }
+
+    if (article.authorId !== userId) {
+      throw new ForbiddenException('Bạn không có quyền chỉnh sửa bài viết!');
+    }
+
+    return this.prisma.article.update({
+      where: { slug },
+      data: updateArticleDto,
+    });
+  }
+
+  async delete(slug: string, userId: number) {
+    const article = await this.prisma.article.findUnique({ where: { slug } });
+
+    if (!article) {
+      throw new NotFoundException(`Không tìm thấy bài viết.`);
+    }
+
+    if (article.authorId !== userId) {
+      throw new ForbiddenException('Bạn không có quyền xoá bài viết!');
+    }
+
+    return this.prisma.article.delete({ where: { slug } });
+  }
+}

--- a/src/articles/dto/create-article.dto.ts
+++ b/src/articles/dto/create-article.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsOptional } from 'class-validator';
+
+export class CreateArticleDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  content: string;
+}

--- a/src/articles/dto/create-article.dto.ts
+++ b/src/articles/dto/create-article.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsOptional } from 'class-validator';
+import { IsNotEmpty, IsString, IsOptional, IsBoolean } from 'class-validator';
 
 export class CreateArticleDto {
   @ApiProperty()
@@ -16,4 +16,9 @@ export class CreateArticleDto {
   @IsNotEmpty()
   @IsString()
   content: string;
+
+  @ApiProperty({ required: false, default: false })
+  @IsOptional()
+  @IsBoolean()
+  published?: boolean = false;
 }

--- a/src/articles/dto/update-article.dto.ts
+++ b/src/articles/dto/update-article.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateArticleDto } from './create-article.dto';
+
+export class UpdateArticleDto extends PartialType(CreateArticleDto) {}

--- a/src/common/pagination.dto.ts
+++ b/src/common/pagination.dto.ts
@@ -6,12 +6,12 @@ export class PaginationDto {
   @IsInt()
   @Min(1)
   @IsOptional()
-  page?: number = 1;
+  page?: number;
 
   @Type(() => Number)
   @IsInt()
   @Min(1)
   @Max(100)
   @IsOptional()
-  limit?: number = 10;
+  limit?: number;
 }

--- a/src/common/pagination.dto.ts
+++ b/src/common/pagination.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min, IsOptional, Max } from 'class-validator';
+
+export class PaginationDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page?: number = 1;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  limit?: number = 10;
+}

--- a/src/constants/pagination.constant.ts
+++ b/src/constants/pagination.constant.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_LIMIT = 10;


### PR DESCRIPTION
Pull request này xây dựng bộ API CRUD (Create, Read, Update, Delete) hoàn chỉnh cho chức năng quản lý Articles. Cho phép người dùng tạo bài viết mới, xem danh sách bài viết, đọc một bài viết cụ thể, cũng như cập nhật và xóa các bài viết mà họ sở hữu.

Các endpoint được phân chia rõ ràng thành hai nhóm: Public (cho tất cả người dùng và khách) và Protected (chỉ dành cho người dùng đã đăng nhập).

Thay đổi chính: 
- Core & Database: Tạo model Article với các trường title, description, content, và published. Thêm trường slug với ràng buộc @unique để tạo ra các URL thân thiện với SEO và người dùng. Và thiết lập mối quan hệ với model User
- API: Chia 2 nhánh chính
          Public Endpoints (Không cần xác thực):
          - GET /api/articles/all: Lấy danh sách tất cả các bài viết đã được xuất bản.
          - GET /api/articles/:slug: Lấy thông tin chi tiết của một bài viết cụ thể dựa trên slug.
          Protected Endpoints (Yêu cầu JWT Authentication):
          - POST /api/articles: Tạo một bài viết mới. slug sẽ được tự động sinh ra từ title.
          - GET /api/articles: Lấy danh sách các bài viết do người dùng hiện tại tạo
          - PUT /api/articles/:slug: Cập nhật một bài viết hiện có.
          - DELETE /api/articles/:slug: Xóa một bài viết.
- Authorization (Kiểm tra quyền): Implement logic kiểm tra quyền sở hữu trong các phương thức update và delete của ArticlesService. Hệ thống sẽ ném ra lỗi ForbiddenException (403) nếu người dùng cố gắng sửa hoặc xóa bài viết không thuộc về họ.
- Validation & DTO: Tạo CreateArticleDto và UpdateArticleDto để validate dữ liệu đầu vào cho việc tạo và cập nhật bài viết.
- Xử lý phân trang cho các bài viết