### PR TITLE
feat(comments): Implement get, create, delete comments endpoints

### DIFF
--- a/prisma/migrations/20250720163128_add_comment_models/migration.sql
+++ b/prisma/migrations/20250720163128_add_comment_models/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `Comment` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `body` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `authorId` INTEGER NOT NULL,
+    `articleId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Comment` ADD CONSTRAINT `Comment_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Comment` ADD CONSTRAINT `Comment_articleId_fkey` FOREIGN KEY (`articleId`) REFERENCES `Article`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   updatedAt DateTime @updatedAt
 
   articles  Article[]
+  comments Comment[]
 }
 
 model Article {
@@ -38,4 +39,18 @@ model Article {
 
   author    User     @relation(fields: [authorId], references: [id])
   authorId  Int
+  comments Comment[]
+}
+
+model Comment {
+  id        Int      @id @default(autoincrement())
+  body      String   
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  authorId  Int
+  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+
+  articleId Int
+  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,16 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { ArticlesModule } from './articles/articles.module';
+import { CommentsModule } from './comments/comments.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, UsersModule, ArticlesModule],
+  imports: [
+    PrismaModule,
+    AuthModule,
+    UsersModule,
+    ArticlesModule,
+    CommentsModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { User } from 'generated/prisma';
+import { CommentsService } from './comments.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { GetUser } from 'src/auth/decorator/get-user.decorator';
+import { ApiBearerAuth } from '@nestjs/swagger';
+
+@Controller('/api/articles/:slug/comments')
+export class CommentsController {
+  constructor(private readonly commentsService: CommentsService) {}
+
+  @Get()
+  async getComments(@Param('slug') slug: string) {
+    return this.commentsService.findComments(slug);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Post()
+  async createComment(
+    @GetUser() user: User,
+    @Param('slug') slug: string,
+    @Body() createCommentDto: CreateCommentDto,
+  ) {
+    return this.commentsService.create(slug, createCommentDto, user.id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Delete(':id')
+  async delete(
+    @GetUser() user: User,
+    @Param('slug') slug: string,
+    @Param('id') id: number,
+  ) {
+    return this.commentsService.delete(slug, id, user.id);
+  }
+}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CommentsService } from './comments.service';
+import { CommentsController } from './comments.controller';
+
+@Module({
+  controllers: [CommentsController],
+  providers: [CommentsService],
+})
+export class CommentsModule {}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,0 +1,107 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+
+@Injectable()
+export class CommentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(
+    slug: string,
+    createCommentDto: CreateCommentDto,
+    userId: number,
+  ) {
+    const article = await this.validateArticleSlug(slug);
+
+    const comment = await this.prisma.comment.create({
+      data: {
+        body: createCommentDto.body,
+        author: {
+          connect: { id: userId },
+        },
+        article: {
+          connect: { id: article.id },
+        },
+      },
+      select: {
+        id: true,
+        body: true,
+        createdAt: true,
+        updatedAt: true,
+        author: {
+          select: {
+            username: true,
+            bio: true,
+            avatar: true,
+          },
+        },
+      },
+    });
+
+    return {
+      comment,
+    };
+  }
+
+  async findComments(slug: string) {
+    const article = await this.validateArticleSlug(slug);
+
+    const comments = await this.prisma.comment.findMany({
+      where: { articleId: article.id },
+      select: {
+        id: true,
+        body: true,
+        createdAt: true,
+        updatedAt: true,
+        author: {
+          select: {
+            username: true,
+            bio: true,
+            avatar: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    return {
+      comments: [...comments],
+    };
+  }
+
+  async delete(slug: string, commentId: number, userId: number) {
+    const article = await this.validateArticleSlug(slug);
+
+    const comment = await this.prisma.comment.findUnique({
+      where: { id: commentId },
+    });
+
+    if (!comment) {
+      throw new NotFoundException('Không tìm thấy bình luận.');
+    }
+
+    if (comment.authorId !== userId) {
+      throw new BadRequestException('Bạn không có quyền xoá bình luận này');
+    }
+
+    return this.prisma.comment.delete({
+      where: { id: commentId },
+    });
+  }
+
+  private async validateArticleSlug(slug: string) {
+    const article = await this.prisma.article.findUnique({ where: { slug } });
+
+    if (!article) {
+      throw new NotFoundException(`Không tìm thấy bài viết.`);
+    }
+
+    return article;
+  }
+}

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsString()
+  @IsNotEmpty()
+  body: string;
+}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -2,8 +2,14 @@ import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService extends PrismaClient
-  implements OnModuleInit, OnModuleDestroy {
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  constructor() {
+    super({ log: ['query', 'info', 'warn', 'error'] });
+  }
+
   async onModuleInit() {
     await this.$connect();
   }


### PR DESCRIPTION
Pull request này xây dựng bộ API CRD cho chức năng quản lý các Comments. Cho phép người dùng tạo comment cho bài viết, xem comment và xóa các comment của họ

Thay đổi chính:

Core & Database: Tạo model Comment với các trường body, authorId, articleId. Thiết lập mối quan hệ với model User và Article
Các API bao gồm: 
- Get /api/articles/:slug/comments: Lấy danh sách comment của bài biết.
- Post /api/articles/:slug/comments: Tạo comment mới.
- Delete /api/articles/:slug/comments/:id: Xoá comment.


Validation & DTO: Tạo CreateCommentDto để validate dữ liệu đầu vào cho việc tạo comment.
