### PR TITLE
feat(favorite): implement favorite, unfavorite articles endpoints

### DIFF
--- a/prisma/migrations/20250721164926_add_favorite_model/migration.sql
+++ b/prisma/migrations/20250721164926_add_favorite_model/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE `Article` ADD COLUMN `favoriteCount` INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE `Favorite` (
+    `userId` INTEGER NOT NULL,
+    `articleId` INTEGER NOT NULL,
+    `favoritedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`userId`, `articleId`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Favorite` ADD CONSTRAINT `Favorite_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Favorite` ADD CONSTRAINT `Favorite_articleId_fkey` FOREIGN KEY (`articleId`) REFERENCES `Article`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,8 @@ model User {
 
   articles  Article[]
   comments Comment[]
+  
+  favorites Favorite[]
 }
 
 model Article {
@@ -40,6 +42,9 @@ model Article {
   author    User     @relation(fields: [authorId], references: [id])
   authorId  Int
   comments Comment[]
+
+  favoritedBy Favorite[]
+  favoriteCount Int @default(0)
 }
 
 model Comment {
@@ -53,4 +58,15 @@ model Comment {
 
   articleId Int
   article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+}
+
+model Favorite {
+  userId    Int
+  articleId Int
+  favoritedAt DateTime @default(now())
+
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  @@id([userId, articleId])
 }

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -27,6 +27,13 @@ export class ArticlesController {
     return this.articlesService.findAll(paginationDto);
   }
 
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Get('me')
+  getMyArticles(@GetUser() user: User, @Query() paginationDto: PaginationDto) {
+    return this.articlesService.findUserArticles(user.id, paginationDto);
+  }
+
   @Get(':slug')
   findBySlug(@Param('slug') slug: string) {
     return this.articlesService.findBySlug(slug);
@@ -37,13 +44,6 @@ export class ArticlesController {
   @Post()
   create(@Body() createArticleDto: CreateArticleDto, @GetUser() user: User) {
     return this.articlesService.create(createArticleDto, user.id);
-  }
-
-  @ApiBearerAuth()
-  @UseGuards(AuthGuard('jwt'))
-  @Get('me')
-  getMyArticles(@GetUser() user: User, @Query() paginationDto: PaginationDto) {
-    return this.articlesService.findUserArticles(user.id, paginationDto);
   }
 
   @ApiBearerAuth()
@@ -62,5 +62,19 @@ export class ArticlesController {
   @Delete(':slug')
   delete(@Param('slug') slug: string, @GetUser() user: User) {
     return this.articlesService.delete(slug, user.id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Post('/:slug/favorite')
+  async favorite(@GetUser() user: User, @Param('slug') slug: string) {
+    return this.articlesService.favorite(slug, user.id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @Delete('/:slug/favorite')
+  async unfavorite(@GetUser() user: User, @Param('slug') slug: string) {
+    return this.articlesService.unfavorite(slug, user.id);
   }
 }

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   Injectable,
@@ -126,6 +127,94 @@ export class ArticlesService {
     await this.validateArticle(slug, userId);
 
     return this.prisma.article.delete({ where: { slug } });
+  }
+
+  async favorite(slug: string, userId: number) {
+    const article = await this.findBySlug(slug);
+    const isFavorited = await this.validateFavorite(userId, article.id);
+
+    if (isFavorited) {
+      throw new BadRequestException('Bạn đã thích bài viết này');
+    }
+
+    const [favorite, updateArticle] = await this.prisma.$transaction([
+      this.prisma.favorite.create({
+        data: {
+          userId: userId,
+          articleId: article.id,
+        },
+      }),
+      this.prisma.article.update({
+        where: { id: article.id },
+        data: {
+          favoriteCount: {
+            increment: 1,
+          },
+        },
+        include: {
+          author: {
+            select: {
+              username: true,
+              bio: true,
+              avatar: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    return updateArticle;
+  }
+
+  async unfavorite(slug: string, userId: number) {
+    const article = await this.findBySlug(slug);
+    const isFavorited = await this.validateFavorite(userId, article.id);
+
+    if (!isFavorited) {
+      throw new BadRequestException('Bạn chưa thích bài viết này');
+    }
+
+    const [favorite, updateArticle] = await this.prisma.$transaction([
+      this.prisma.favorite.delete({
+        where: {
+          userId_articleId: {
+            userId: userId,
+            articleId: article.id,
+          },
+        },
+      }),
+      this.prisma.article.update({
+        where: { id: article.id },
+        data: {
+          favoriteCount: {
+            decrement: 1,
+          },
+        },
+        include: {
+          author: {
+            select: {
+              username: true,
+              bio: true,
+              avatar: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    return updateArticle;
+  }
+
+  private async validateFavorite(userId: number, articleId: number) {
+    const isFavorite = await this.prisma.favorite.findUnique({
+      where: {
+        userId_articleId: {
+          userId: userId,
+          articleId: articleId,
+        },
+      },
+    });
+    return isFavorite;
   }
 
   private async validateArticle(slug: string, userId: number) {


### PR DESCRIPTION
Pull request này xây dựng bộ chức năng yêu thích một bài viết. Cho phép người dùng thích hoặc không thích một bài viết ngoài ra xem được số lượt thích của bài viết.

Thay đổi chính:

Core & Database: Tạo model Favorite với các trường authorId, articleId. Thiết lập mối quan hệ với model User và Article
Các API bao gồm:

POST /api/articles/:slug/favorite: Trả về bài viết yêu thích, tăng số lượt thích bài viết lên.
DELETE /api/articles/:slug/favorite: Bỏ thích bài viết, trả về bài viết và giảm số lượt thích bài viết đó.

**Chú ý** trong pull request này: Đổi vị trí của api GET /api/articles/me lên trước api GET /api/articles/:slug để tránh route conflict