### PR TITLE
Feature/article publishing workflow

### DIFF
--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -54,7 +54,7 @@ export class ArticlesController {
   @UseGuards(AuthGuard('jwt'))
   @Patch('publish')
   publishArticles(
-    @Body() publishDto: PublishArticlesDto, // 3. Lấy và validate body với DTO
+    @Body() publishDto: PublishArticlesDto,
     @GetUser() user: User,
   ) {
     return this.articlesService.publish(publishDto, user.id);

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -13,6 +13,7 @@ import { skip } from 'rxjs';
 import { PaginationDto } from 'src/common/pagination.dto';
 import { DEFAULT_LIMIT, DEFAULT_PAGE } from 'src/constants/pagination.constant';
 import { I18nService } from 'nestjs-i18n';
+import { PublishArticlesDto } from './dto/publish-articles.dto';
 
 @Injectable()
 export class ArticlesService {
@@ -79,6 +80,36 @@ export class ArticlesService {
     const { page = DEFAULT_PAGE, limit = DEFAULT_LIMIT } = paginationDto;
     const skip = (page - 1) * limit;
 
+    const whereClause = { authorId: authorId, published: true };
+
+    const [total, articles] = await this.prisma.$transaction([
+      this.prisma.article.count({ where: whereClause }),
+      this.prisma.article.findMany({
+        where: whereClause,
+        include: { author: { select: { username: true } } },
+        skip: skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+    ]);
+
+    const totalPages = Math.ceil(total / limit);
+
+    return {
+      data: articles,
+      meta: {
+        totalItems: total,
+        itemsPerPage: limit,
+        totalPages: totalPages,
+        currentPage: page,
+      },
+    };
+  }
+
+  async findMyArticles(authorId: number, paginationDto: PaginationDto) {
+    const { page = DEFAULT_PAGE, limit = DEFAULT_LIMIT } = paginationDto;
+    const skip = (page - 1) * limit;
+
     const whereClause = { authorId: authorId };
 
     const [total, articles] = await this.prisma.$transaction([
@@ -105,16 +136,25 @@ export class ArticlesService {
     };
   }
 
-  async findBySlug(slug: string) {
+  async findBySlug(slug: string, userId?: number) {
     const article = await this.prisma.article.findUnique({
       where: { slug },
       include: { author: { select: { username: true } } },
     });
+
     if (!article) {
       throw new NotFoundException(
         this.i18n.translate('articles.article_not_found'),
       );
     }
+
+    if (!article.published) {
+      if (article.authorId !== userId)
+        throw new NotFoundException(
+          this.i18n.translate('articles.article_not_found'),
+        );
+    }
+
     return article;
   }
 
@@ -211,6 +251,38 @@ export class ArticlesService {
     ]);
 
     return updateArticle;
+  }
+
+  async publish(publishDto: PublishArticlesDto, userId: number) {
+    const { slugs } = publishDto;
+
+    const result = await this.prisma.article.updateMany({
+      where: {
+        slug: {
+          in: slugs,
+        },
+        authorId: userId,
+        published: false,
+      },
+      data: {
+        published: true,
+        updatedAt: new Date(),
+      },
+    });
+
+    if (result.count === 0) {
+      throw new BadRequestException(
+        this.i18n.translate('articles.no_articles_to_publish'),
+      );
+    }
+
+    const message = this.i18n.translate(
+      'articles.successfully_published_articles',
+    );
+    return {
+      message: message,
+      count: result.count,
+    };
   }
 
   private async validateFavorite(userId: number, articleId: number) {

--- a/src/articles/dto/publish-articles.dto.ts
+++ b/src/articles/dto/publish-articles.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNotEmpty, IsString, ArrayNotEmpty } from 'class-validator';
+
+export class PublishArticlesDto {
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  slugs: string[];
+}

--- a/src/auth/optional-jwt-auth.guard.ts
+++ b/src/auth/optional-jwt-auth.guard.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+  handleRequest(err, user, info, context, status) {
+    return user;
+  }
+}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -128,7 +128,9 @@ export class CommentsService {
   }
 
   private async validateArticleSlug(slug: string) {
-    const article = await this.prisma.article.findUnique({ where: { slug } });
+    const article = await this.prisma.article.findUnique({
+      where: { slug, published: true },
+    });
 
     if (!article) {
       throw new NotFoundException(

--- a/src/i18n/en/articles.json
+++ b/src/i18n/en/articles.json
@@ -3,5 +3,7 @@
   "article_not_found": "Article not found.",
   "can_not_pemission": "You do not have permission to perform this action!",
   "liked": "You liked this post.",
-  "unliked": "You haven't liked this post"
+  "unliked": "You haven't liked this post",
+  "no_articles_to_publish": "No articles to publish",
+  "successfully_published_articles": "Successfully published articles."
 }

--- a/src/i18n/ja/articles.json
+++ b/src/i18n/ja/articles.json
@@ -3,5 +3,7 @@
   "article_not_found": "記事が見つかりません。",
   "can_not_pemission": "この操作を実行する権限がありません。",
   "liked": "この投稿が好きです。",
-  "unliked": "この投稿がまだ好きではありません。"
+  "unliked": "この投稿がまだ好きではありません。",
+  "no_articles_to_publish": "まだ公開できる記事がありません",
+  "successfully_published_articles": "件の記事を公開しました。"
 }

--- a/src/i18n/vi/articles.json
+++ b/src/i18n/vi/articles.json
@@ -3,5 +3,7 @@
   "article_not_found": "Không tìm thấy bài viết.",
   "can_not_pemission": "Bạn không có quyền thực hiện hành động này!",
   "liked": "Bạn đã thích bài viết này.",
-  "unliked": "Bạn chưa thích bài viết này"
+  "unliked": "Bạn chưa thích bài viết này",
+  "no_articles_to_publish": "Hiện chưa có bài viết nào để xuất bản.",
+  "successfully_published_articles": "Xuất bản bài viết thành công."
 }


### PR DESCRIPTION
pull request này cải thiện tính năng published bài viết từ pull request 3 (lên ý tưởng và code 1 phần). Cho phép người dùng publish 1 hoặc nhiều bài viết cùng lúc. Những bài đã publish mới có thể được xem và tương tác bởi những người khác.
Các thay đổi chính:

1. API:
- Get api/articles/me: Lấy các bài viết của người dùng (bao gồm các bài viết chưa hoàn thiện).
- Get api/articles/user/:id: Xem tất cả các bài viết của người dùng khác (:id) (chỉ xem được các bài publish)
- Patch api/articles/publish: Publish các bài viết cùng 1 lúc
- Get api/articles/:slug: Cho phép người dùng xem chi tiết 1 bài viết (publish). Còn bài viết chưa hoàn thiện thì chỉ có tác giả mới có thể xem chi tiết chúng.

2. Tạo một "Guard Tùy chọn" (Optional Guard): JwtAuthGuard mặc định sẽ chặn request nếu không có token hợp lệ. Chúng ta cần một Guard mới để xác thực người dùng, nếu thành công thì gắn user vào request, nếu không thì cứ cho qua mà không báo lỗi.

3. Validation & DTO: Tạo PublishArticlesDto để validate dữ liệu đầu vào cho việc publish các bài viết.